### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,7 @@
       <version>1.7.36</version>
     </dependency>
 
-    <dependency>
-      <groupId>io.github.bonigarcia</groupId>
-      <artifactId>webdrivermanager</artifactId>
-      <version>5.3.2</version>
-      <scope>test</scope>
-    </dependency>
+  
 
     <dependency>
       <groupId>io.github.bonigarcia</groupId>


### PR DESCRIPTION
If a Maven pom.xml file contains two identical dependencies, it is generally considered redundant and can be considered bad practice

*Increased download and build time

*Potential version conflicts

*Maintenance and readability